### PR TITLE
Persist moods and venting posts to Supabase and wire quick actions

### DIFF
--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -1,29 +1,35 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus, Target, BookOpen, Gamepad2, TrendingUp } from "lucide-react";
+import { Plus, Target, Gamepad2, TrendingUp } from "lucide-react";
 
-const QuickActions = () => {
+interface QuickActionsProps {
+  onDailyGoal: () => void;
+  onVybeStrike: () => void;
+  onVybeTree: () => void;
+}
+
+const QuickActions = ({ onDailyGoal, onVybeStrike, onVybeTree }: QuickActionsProps) => {
   const actions = [
     {
       icon: Target,
       label: "Daily Goal",
       description: "Set today's focus",
-      onClick: () => console.log("Goal"),
-      gradient: "from-purple-500 to-pink-500"
+      onClick: onDailyGoal,
+      gradient: "from-purple-500 to-pink-500",
     },
     {
       icon: Gamepad2,
       label: "VybeStrike",
       description: "Level up challenge",
-      onClick: () => console.log("Game"),
-      gradient: "from-green-500 to-teal-500"
+      onClick: onVybeStrike,
+      gradient: "from-green-500 to-teal-500",
     },
     {
       icon: TrendingUp,
       label: "VybeTree",
       description: "Check progress",
-      onClick: () => console.log("Tree"),
-      gradient: "from-orange-500 to-yellow-500"
+      onClick: onVybeTree,
+      gradient: "from-orange-500 to-yellow-500",
     },
   ];
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -154,7 +154,11 @@ const Index = () => {
             <MoodTracker />
           </div>
           <div className="animate-fade-in" style={{ animationDelay: '0.5s' }}>
-            <QuickActions />
+            <QuickActions
+              onDailyGoal={() => setCurrentView('vybestryke')}
+              onVybeStrike={() => setCurrentGame('vybestryke')}
+              onVybeTree={() => setCurrentView('vybetree')}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- wire quick actions into dashboard navigation
- store venting posts in Supabase instead of local storage
- track mood entries in Supabase and display recent history
- persist theme selection to Supabase user preferences

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in ui/textarea and no-require-imports in tailwind.config.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689514be25b08321b106fea2ee417b16