### PR TITLE
feat: enrich design system and progress visuals

### DIFF
--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Plus, Target, BookOpen, Gamepad2, TrendingUp } from "lucide-react";
+import { Plus, Target, Gamepad2, TrendingUp } from "lucide-react";
 
 const QuickActions = () => {
   const actions = [
@@ -8,23 +8,20 @@ const QuickActions = () => {
       icon: Target,
       label: "Daily Goal",
       description: "Set today's focus",
-      onClick: () => console.log("Goal"),
-      gradient: "from-purple-500 to-pink-500"
+      onClick: () => console.log("Goal")
     },
     {
       icon: Gamepad2,
       label: "VybeStrike",
       description: "Level up challenge",
-      onClick: () => console.log("Game"),
-      gradient: "from-green-500 to-teal-500"
+      onClick: () => console.log("Game")
     },
     {
       icon: TrendingUp,
       label: "VybeTree",
       description: "Check progress",
-      onClick: () => console.log("Tree"),
-      gradient: "from-orange-500 to-yellow-500"
-    },
+      onClick: () => console.log("Tree")
+    }
   ];
 
   return (
@@ -43,18 +40,16 @@ const QuickActions = () => {
             <Button
               key={action.label}
               variant="ghost"
-              className="h-20 p-4 flex flex-col items-center gap-2 hover:bg-secondary/50 group transition-all duration-300 hover:scale-105"
+              className="h-20 p-4 flex flex-col items-center gap-2 bg-gradient-to-br from-vy.pop to-vy.neon rounded-2xl shadow-lg text-vy.ink transform transition-transform duration-300 hover:rotate-2 hover:scale-105 hover:shadow-xl"
               onClick={action.onClick}
               style={{
                 animationDelay: `${index * 100}ms`
               }}
             >
-              <div className={`p-2 rounded-lg bg-gradient-to-r ${action.gradient} group-hover:scale-110 transition-transform duration-200`}>
-                <Icon className="w-5 h-5 text-white" />
-              </div>
+              <Icon className="w-5 h-5" />
               <div className="text-center">
-                <div className="text-sm font-medium text-foreground">{action.label}</div>
-                <div className="text-xs text-muted-foreground">{action.description}</div>
+                <div className="text-sm font-medium">{action.label}</div>
+                <div className="text-xs opacity-80">{action.description}</div>
               </div>
             </Button>
           );

--- a/src/components/VybeStrykes.tsx
+++ b/src/components/VybeStrykes.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
+import { ProgressRing } from "@/components/ui/ProgressRing";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/integrations/supabase/client";
 
@@ -171,7 +171,9 @@ const VybeStryks = ({ onBack }: VybeStryksProps) => {
 
   const scenario = scenarios[currentScenario];
 
-  const updateStats = async (impacts: any) => {
+  type StatImpacts = Scenario["statImpacts"];
+
+  const updateStats = async (impacts: StatImpacts) => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
@@ -288,7 +290,7 @@ const VybeStryks = ({ onBack }: VybeStryksProps) => {
             <span className="text-sm text-muted-foreground">
               Scenario {currentScenario + 1} of {scenarios.length}
             </span>
-            <Progress value={(currentScenario / scenarios.length) * 100} className="flex-1" />
+            <ProgressRing progress={(currentScenario / scenarios.length) * 100} />
             <span className="text-sm font-medium">Score: {score}</span>
           </div>
 

--- a/src/components/VyralStats.tsx
+++ b/src/components/VyralStats.tsx
@@ -6,21 +6,22 @@ interface StatBarProps {
   label: string;
   value: number;
   maxValue: number;
-  color?: string;
 }
 
-const StatBar = ({ label, value, maxValue, color = "primary" }: StatBarProps) => {
+const StatBar = ({ label, value, maxValue }: StatBarProps) => {
   const percentage = Math.min((value / maxValue) * 100, 100);
-  
+
   return (
-    <div className="space-y-2">
-      <div className="flex justify-between items-center">
-        <span className="text-sm font-medium text-foreground">{label}</span>
-        <span className="text-xs text-muted-foreground">{value}/{maxValue}</span>
+    <div className="mb-3">
+      <div className="flex justify-between text-sm font-medium text-vy.neon mb-1">
+        <span>{label}</span>
+        <span>
+          {value}/{maxValue}
+        </span>
       </div>
-      <div className="vyral-stat-bar">
-        <div 
-          className="vyral-stat-fill transition-all duration-300 ease-out"
+      <div className="h-2 bg-vy.bg/40 rounded-full">
+        <div
+          className="h-full rounded-full bg-gradient-to-r from-vy.neon via-vy.pop to-vy.gold shadow-[0_0_6px_#41F3FF] transition-[width] duration-700"
           style={{ width: `${percentage}%` }}
         />
       </div>

--- a/src/components/ui/ProgressRing.tsx
+++ b/src/components/ui/ProgressRing.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+interface ProgressRingProps {
+  progress: number;
+  size?: number;
+  strokeWidth?: number;
+}
+
+export function ProgressRing({
+  progress,
+  size = 64,
+  strokeWidth = 6
+}: ProgressRingProps) {
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (progress / 100) * circumference;
+
+  return (
+    <svg width={size} height={size} className="text-vy.neon">
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+        stroke="currentColor"
+        className="opacity-20"
+        fill="transparent"
+      />
+      <circle
+        cx={size / 2}
+        cy={size / 2}
+        r={radius}
+        strokeWidth={strokeWidth}
+        stroke="currentColor"
+        fill="transparent"
+        strokeDasharray={circumference}
+        strokeDashoffset={offset}
+        style={{ transition: "stroke-dashoffset 1.2s" }}
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animatePlugin from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -48,26 +49,35 @@ export default {
 					DEFAULT: 'hsl(var(--popover))',
 					foreground: 'hsl(var(--popover-foreground))'
 				},
-				card: {
-					DEFAULT: 'hsl(var(--card))',
-					foreground: 'hsl(var(--card-foreground))'
-				},
-				sidebar: {
-					DEFAULT: 'hsl(var(--sidebar-background))',
-					foreground: 'hsl(var(--sidebar-foreground))',
-					primary: 'hsl(var(--sidebar-primary))',
-					'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+                                card: {
+                                        DEFAULT: 'hsl(var(--card))',
+                                        foreground: 'hsl(var(--card-foreground))'
+                                },
+                                vy: {
+                                        bg: '#0B0F14',
+                                        ink: '#E6F1FF',
+                                        neon: '#41F3FF',
+                                        pop: '#FF2ED1',
+                                        gold: '#FFC857'
+                                },
+                                sidebar: {
+                                        DEFAULT: 'hsl(var(--sidebar-background))',
+                                        foreground: 'hsl(var(--sidebar-foreground))',
+                                        primary: 'hsl(var(--sidebar-primary))',
+                                        'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
 					accent: 'hsl(var(--sidebar-accent))',
 					'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
 					border: 'hsl(var(--sidebar-border))',
 					ring: 'hsl(var(--sidebar-ring))'
 				}
 			},
-			borderRadius: {
-				lg: 'var(--radius)',
-				md: 'calc(var(--radius) - 2px)',
-				sm: 'calc(var(--radius) - 4px)'
-			},
+                        borderRadius: {
+                                lg: 'var(--radius)',
+                                md: 'calc(var(--radius) - 2px)',
+                                sm: 'calc(var(--radius) - 4px)',
+                                xl: '1.25rem',
+                                '2xl': '1.5rem'
+                        },
 			keyframes: {
 				'accordion-down': {
 					from: {
@@ -190,5 +200,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animatePlugin],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add bespoke `vy` color palette and extra radii to Tailwind config
- animate stat bars with gradient fill and glow
- rework quick actions with neon-to-pop gradient cards
- create reusable `ProgressRing` and show scenario progress in VybeStrykes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/VyralStats.tsx src/components/QuickActions.tsx src/components/ui/ProgressRing.tsx src/components/VybeStrykes.tsx tailwind.config.ts`

------
https://chatgpt.com/codex/tasks/task_e_68975032e5fc8321bd078399513c3f60